### PR TITLE
Include header <memory> explicitly.

### DIFF
--- a/stress_test/Mixer.h
+++ b/stress_test/Mixer.h
@@ -2,6 +2,7 @@
 
 #include <random>
 #include <vector>
+#include <memory>
 
 #include "Distribution.h"
 #include "Producers.h"


### PR DESCRIPTION
Under gcc version `gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3)`, the build is failing because it does not recognize `std::shared_ptr`. Including header `<memory>` explicitly to solve the problem.